### PR TITLE
added domain HELO support

### DIFF
--- a/src/Commands/SendCommand.php
+++ b/src/Commands/SendCommand.php
@@ -146,6 +146,10 @@ class SendCommand extends Command
                     $phpMailer->Host = $value;
                     break;
 
+                case 'domain':
+                    $phpMailer->Helo = $value;
+                    break;
+
                 case 'port':
                     $phpMailer->Port = $value;
                     break;


### PR DESCRIPTION
Services like Mailgun require that you send a domain in the HELO.